### PR TITLE
[MongodbPlugin] Convert to string when args[0] is an array

### DIFF
--- a/src/Plugins/MongodbPlugin.php
+++ b/src/Plugins/MongodbPlugin.php
@@ -18,7 +18,10 @@ class MongodbPlugin extends Candy
 
         if ($this->who instanceof \yii\mongodb\Command)
         {
-            pinpoint_add_clues(PP_PHP_ARGS, sprintf("%s", isset($this->args[0]) ? $this->args[0] : ''));
+            pinpoint_add_clues(PP_PHP_ARGS, sprintf("%s", isset($this->args[0]) ?
+                is_array($this->args[0]) ? implode(" ", $this->args[0]) : $this->args[0] :
+                ''
+            ));
             pinpoint_add_clues(PP_SQL, print_r($this->who->document, true));
         }
     }


### PR DESCRIPTION
Convert to string when pinpoint\PluginsCore\Common\Candy args[0] is an array